### PR TITLE
fix(deploy): fix ACR tag verification in distribute task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,8 +147,9 @@ tasks:
       - docker tag {{.IMAGE_NAME}}:latest {{.ACR_IMAGE}}:{{.IMAGE_TAG}}
       # Push to ACR
       - docker push {{.ACR_IMAGE}}:{{.IMAGE_TAG}}
-      # Verify image exists in ACR
-      - az acr repository show-tags --name {{.ACR_NAME}} --repository todo-app --filter "{{.IMAGE_TAG}}" --output tsv | grep -q "{{.IMAGE_TAG}}"
+      # Verify image exists in ACR (brief delay for ACR to index the tag)
+      - sleep 0.5
+      - az acr repository show-tags --name {{.ACR_NAME}} --repository todo-app --output tsv | grep -qF "{{.IMAGE_TAG}}"
 
   deploy:
     desc: Deploy the container image to Azure Container Apps
@@ -160,7 +161,7 @@ tasks:
       APP_NAME: '{{.APP_NAME | default "todo-app"}}'
     cmds:
       # Verify image exists in ACR before deploying
-      - az acr repository show-tags --name {{.ACR_NAME}} --repository todo-app --filter "{{.IMAGE_TAG}}" --output tsv | grep -q "{{.IMAGE_TAG}}"
+      - az acr repository show-tags --name {{.ACR_NAME}} --repository todo-app --output tsv | grep -qF "{{.IMAGE_TAG}}"
       - |
         az containerapp update \
           --name {{.APP_NAME}} \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,9 +147,14 @@ tasks:
       - docker tag {{.IMAGE_NAME}}:latest {{.ACR_IMAGE}}:{{.IMAGE_TAG}}
       # Push to ACR
       - docker push {{.ACR_IMAGE}}:{{.IMAGE_TAG}}
-      # Verify image exists in ACR (brief delay for ACR to index the tag)
-      - sleep 0.5
-      - az acr repository show-tags --name {{.ACR_NAME}} --repository todo-app --output tsv | grep -qF "{{.IMAGE_TAG}}"
+      # Verify image exists in ACR (retry with backoff for ACR to index the tag)
+      - |
+        sleep 0.5
+        if ! az acr repository show-tags --name {{.ACR_NAME}} --repository todo-app --output tsv | grep -qF "{{.IMAGE_TAG}}"; then
+          echo "Tag not yet available, retrying in 5s..."
+          sleep 5
+          az acr repository show-tags --name {{.ACR_NAME}} --repository todo-app --output tsv | grep -qF "{{.IMAGE_TAG}}"
+        fi
 
   deploy:
     desc: Deploy the container image to Azure Container Apps


### PR DESCRIPTION
## Summary
- Remove invalid `--filter` flag from `az acr repository show-tags` that caused the distribute step to fail after a successful image push
- Use `grep -qF` for fixed-string matching instead of regex to avoid potential false matches
- Add retry with backoff (0.5s initial, 5s retry) for ACR tag verification to handle indexing delays

## Test plan
- [ ] Verify deploy workflow passes on the next push to main
- [x] Confirm `az acr repository show-tags` returns expected tags without `--filter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)